### PR TITLE
Use namespace cvmfs for all deployments and rbac

### DIFF
--- a/deployments/kubernetes/csi-config-map.yaml
+++ b/deployments/kubernetes/csi-config-map.yaml
@@ -6,3 +6,4 @@ data:
     []
 metadata:
   name: cvmfs-csi-config
+  namespace: cvmfs

--- a/deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml
+++ b/deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: csi-cvmfsplugin-provisioner
-  namespace: kube-system 
+  namespace: cvmfs
   labels:
     app: csi-cvmfsplugin-provisioner
 spec:
@@ -18,7 +18,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-cvmfsplugin-provisioner
-  namespace: kube-system
+  namespace: cvmfs
 spec:
   selector:
     matchLabels:

--- a/deployments/kubernetes/csi-cvmfsplugin.yaml
+++ b/deployments/kubernetes/csi-cvmfsplugin.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 apiVersion: apps/v1beta2
 metadata:
   name: csi-cvmfsplugin
-  namespace: kube-system
+  namespace: cvmfs
 spec:
   selector:
     matchLabels:

--- a/deployments/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deployments/kubernetes/csi-nodeplugin-rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cvmfs-csi-nodeplugin
-  namespace: kube-system
+  namespace: cvmfs
 
 ---
 kind: ClusterRole
@@ -45,7 +45,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cvmfs-csi-nodeplugin
-    namespace: kube-system
+    namespace: cvmfs
 roleRef:
   kind: ClusterRole
   name: cvmfs-csi-nodeplugin

--- a/deployments/kubernetes/csi-provisioner-rbac.yaml
+++ b/deployments/kubernetes/csi-provisioner-rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cvmfs-csi-provisioner
-  namespace: kube-system
+  namespace: cvmfs
 
 ---
 kind: ClusterRole
@@ -65,7 +65,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: kube-system
+  namespace: cvmfs
   name: cvmfs-external-provisioner-cfg
 rules:
   - apiGroups: [""]
@@ -83,11 +83,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cvmfs-csi-provisioner-role-cfg
-  namespace: kube-system
+  namespace: cvmfs
 subjects:
   - kind: ServiceAccount
     name: cvmfs-csi-provisioner
-    namespace: kube-system
+    namespace: cvmfs
 roleRef:
   kind: Role
   name: cvmfs-external-provisioner-cfg

--- a/deployments/kubernetes/csidriver-crd.yaml
+++ b/deployments/kubernetes/csidriver-crd.yaml
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: csi-cvmfsplugin
-  namespace: kube-system
+  namespace: cvmfs
 spec:
   attachRequired: false
   podInfoOnMount: false


### PR DESCRIPTION
The components inconsistently use both `cvmfs` and `kube-system` namespaces. I think it would be best for everything to reside in the `cvmfs` namespace. This would allow easy validation of the setup after deployment and streamline troubleshooting steps. 

[Verifying the deployment in Kubernetes](https://github.com/cernops/cvmfs-csi#verifying-the-deployment-in-kubernetes) shows all components in the same namespace. 