### PR TITLE
Deploy only one replica of cvmfsplugin provisioner

### DIFF
--- a/deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml
+++ b/deployments/kubernetes/csi-cvmfsplugin-provisioner.yaml
@@ -23,7 +23,7 @@ spec:
   selector:
     matchLabels:
       app: csi-cvmfsplugin-provisioner
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
The `csi-provisioner` sidecar container runs a lock on the repository causing 2/3 of the replicas to complain that it cannot acquire a lease. This may be node specific as I'm running them on a single node. It may be better to run this as a DaemonSet instead of a Deployment. 

```
I0312 16:58:28.835703       1 leaderelection.go:326] lock is held by csi-cvmfsplugin-provisioner-5f5b77c4d-jtv74 and has not yet expired
I0312 16:58:28.835736       1 leaderelection.go:222] failed to acquire lease cvmfs/cvmfs-csi-cern-ch
I0312 16:58:35.554670       1 leaderelection.go:326] lock is held by csi-cvmfsplugin-provisioner-5f5b77c4d-jtv74 and has not yet expired
I0312 16:58:35.554704       1 leaderelection.go:222] failed to acquire lease cvmfs/cvmfs-csi-cern-ch
I0312 16:58:45.891097       1 leaderelection.go:326] lock is held by csi-cvmfsplugin-provisioner-5f5b77c4d-jtv74 and has not yet expired
I0312 16:58:45.891130       1 leaderelection.go:222] failed to acquire lease cvmfs/cvmfs-csi-cern-ch
I0312 16:58:54.057207       1 leaderelection.go:326] lock is held by csi-cvmfsplugin-provisioner-5f5b77c4d-jtv74 and has not yet expired
I0312 16:58:54.057240       1 leaderelection.go:222] failed to acquire lease cvmfs/cvmfs-csi-cern-ch
I0312 16:59:02.419903       1 leaderelection.go:326] lock is held by csi-cvmfsplugin-provisioner-5f5b77c4d-jtv74 and has not yet expired
I0312 16:59:02.419934       1 leaderelection.go:222] failed to acquire lease cvmfs/cvmfs-csi-cern-ch
```

This PR scales the replicas down to 1 and prevents this lock related error.