### PR TITLE
Comment out repositories values and add it as example

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -38,7 +38,8 @@ configs:
 repositories:
   # The key will be used for the storage class name
   # The value will be used for the repository
-  cern-repo: repository.cern.ch
+  # Example of repositories key value should look like the following:
+  # cern-repo: repository.cern.ch
 
 cache:
   # If both local and alien cache are disabled, ephemeral


### PR DESCRIPTION
Comment out `cern-repo: repository.cern.ch`.
When this is managed by argo-cd, it merges the custom values with the values
specified in values.yaml.

Closes https://github.com/cernops/cvmfs-csi/issues/23